### PR TITLE
fix: by default the side nav is open

### DIFF
--- a/packages/akiradocs/src/components/layout/Navigation.tsx
+++ b/packages/akiradocs/src/components/layout/Navigation.tsx
@@ -49,7 +49,7 @@ export function Navigation({ locale, items }: NavigationProps) {
 }
 
 const NavItem = React.memo(({ locale, item, pathname, depth = 0 }: NavItemProps) => {
-  const [isOpen, setIsOpen] = useState(false)
+  const [isOpen, setIsOpen] = useState(true)
   const hasChildren = item.items && Object.keys(item.items).length > 0
   const isActive = item.path ? pathname === `/${locale}${item.path}` : false
   const absolutePath = item.path ? `/${locale}${item.path}` : '#'


### PR DESCRIPTION
# Enable Expanded Navigation by Default

- **Purpose:**
 Modify the default state of the navigation menu to be open by default.
- **Key Changes:**
  - Set the initial state of the `isOpen` state variable to `true` instead of `false`.
  - This will cause the navigation menu to be expanded and visible when the page loads.
- **Impact:**
 This change will improve the user experience by making the navigation more accessible and easier to use, especially for first-time visitors.

> ✨ Generated with love by [Kaizen](https://cloudcode.ai) ❤️


<details>
<summary>Original Description</summary>
## Description
<!-- Describe your changes in detail -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes 
</details>

