### PR TITLE
Update index.ts: fixed path of editor to root/editor

### DIFF
--- a/packages/create-app/src/index.ts
+++ b/packages/create-app/src/index.ts
@@ -210,7 +210,7 @@ async function main() {
         console.log(chalk.cyan(`  cd ${directory}`));
         console.log(chalk.cyan('  npm install'));
         if (editorResponse.includeEditor) {
-          console.log(chalk.cyan(` cd ${path.join(__dirname, '..', 'components', 'editor')}`));          
+          console.log(chalk.cyan(` cd editor`));          
           console.log(chalk.cyan('  npm install')); 
           console.log(chalk.cyan('  cd .. && npm run dev:all'));
           console.log('\nEditor will be available at: http://localhost:3001');


### PR DESCRIPTION
# Update create-app package

- **Purpose:**
 Simplify the instructions for setting up the editor component
- **Key Changes:**
  - Removed the full path to the editor component directory
  - Updated the instructions to just use `cd editor` instead
  - Kept the remaining instructions for installing dependencies and running the development server
- **Impact:**
 This change makes the setup process more user-friendly by reducing the number of steps required to get the editor component running

> ✨ Generated with love by [Kaizen](https://cloudcode.ai) ❤️


<details>
<summary>Original Description</summary>

## 🔍 Description
Fixes path of editor back to root/editor in create-app's steps shown to user to run the app locally.

## Type
- [x] 🐛 Bug Fix
- [ ] ✨ Feature
- [ ] 📚 Documentation
- [ ] 🔧 Other: _____

## Checklist
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Added/updated tests (if needed)
</details>

