### PR TITLE
fix: automatic metadata generation

### DIFF
--- a/packages/akiradocs/compiled/en/articles/_meta.json
+++ b/packages/akiradocs/compiled/en/articles/_meta.json
@@ -2,7 +2,7 @@
   "defaultRoute": "/articles/welcome",
   "welcome": {
     "title": "Welcome to Akira Doc",
-    "path": "/en/articles/welcome"
+    "path": "/articles/welcome"
   },
   "template": {
     "title": "Test Blog Post",
@@ -10,6 +10,6 @@
   },
   "ai_integration": {
     "title": "Ai Integration",
-    "path": "/en/articles/ai_integration"
+    "path": "/articles/ai_integration"
   }
 }

--- a/packages/akiradocs/compiled/en/docs/_meta.json
+++ b/packages/akiradocs/compiled/en/docs/_meta.json
@@ -2,7 +2,7 @@
   "defaultRoute": "/docs/introduction",
   "introduction": {
     "title": "Introduction",
-    "path": "/en/docs/introduction"
+    "path": "/docs/introduction"
   },
   "guides": {
     "title": "Guides",

--- a/packages/akiradocs/compiled/en/docs/getting-started/_meta.json
+++ b/packages/akiradocs/compiled/en/docs/getting-started/_meta.json
@@ -1,6 +1,0 @@
-{
-  "quickstart": {
-    "title": "Quickstart Guide",
-    "path": "/en/docs/getting-started/quickstart"
-  }
-}

--- a/packages/akiradocs/compiled/en/docs/guides/_meta.json
+++ b/packages/akiradocs/compiled/en/docs/guides/_meta.json
@@ -1,6 +1,0 @@
-{
-  "analytics": {
-    "title": "Analytics Integration",
-    "path": "/en/docs/guides/analytics"
-  }
-}

--- a/packages/akiradocs/public/context/en_docs.txt
+++ b/packages/akiradocs/public/context/en_docs.txt
@@ -1,3 +1,13 @@
+[Document: docs/introduction.json]
+Title: Introduction
+<strong>Akira Docs</strong> is a modern documentation platform that combines the power of AI with an intuitive block-based content system. This guide will help you understand the core concepts and features.
+Key Features
+AI-powered search
+Block-based content editing
+Responsive design
+Customizable themes
+Markdown support
+-------------
 [Document: articles/welcome.json]
 Title: Welcome to Akira Doc
 Get started with Akira Docs - Next-gen documentation powered by AI
@@ -55,16 +65,6 @@ ai_assistant:
   style_guide: "path/to/style/guide.md"
 Next Steps
 Explore our [Advanced AI Features](/advanced-ai-features) guide to learn more about specialized use cases and integration possibilities.
--------------
-[Document: docs/introduction.json]
-Title: Introduction
-<strong>Akira Docs</strong> is a modern documentation platform that combines the power of AI with an intuitive block-based content system. This guide will help you understand the core concepts and features.
-Key Features
-AI-powered search
-Block-based content editing
-Responsive design
-Customizable themes
-Markdown support
 -------------
 [Document: docs/guides/analytics.json]
 Title: Analytics Integration

--- a/packages/akiradocs/scripts/compile.js
+++ b/packages/akiradocs/scripts/compile.js
@@ -242,12 +242,15 @@ async function updateMetaFile(folderPath, newFile) {
       .split('_')
       .map(word => word.charAt(0).toUpperCase() + word.slice(1))
       .join(' ');
+    
+    const pathWithoutLang = relativePath.split(path.sep).slice(1).join(path.sep);
     meta[fileName] = {
       title: compiledContent.title || humanReadableFileName,
-      path: path.join('/', relativePath, fileName)
+      path: path.join('/', pathWithoutLang, fileName)
     };
   } else {
-    meta[fileName].path = path.join('/', relativePath, fileName);
+    const pathWithoutLang = relativePath.split(path.sep).slice(1).join(path.sep);
+    meta[fileName].path = path.join('/', pathWithoutLang, fileName);
   }
 
   await writeFile(metaPath, JSON.stringify(meta, null, 2));
@@ -281,7 +284,7 @@ async function compileMarkdownFiles() {
       await mkdir(path.dirname(compiledPath), { recursive: true });
       await writeFile(compiledPath, JSON.stringify(compiledContent, null, 2));
       
-      await updateMetaFile(path.dirname(compiledPath), compiledPath);
+      // await updateMetaFile(path.dirname(compiledPath), compiledPath);
       
       console.log(`Compiled ${file} -> ${compiledPath}`);
     }
@@ -315,7 +318,7 @@ async function createMetaFilesForAllFolders() {
 
         const jsonFiles = await glob('**/*.json', { 
           cwd: sectionPath,
-          ignore: '**/_meta.json'
+          ignore: ['**/_meta.json']
         });
 
         const meta = {
@@ -326,7 +329,7 @@ async function createMetaFilesForAllFolders() {
           const fileName = path.basename(jsonFile, '.json');
           const filePath = path.join(sectionPath, jsonFile);
           const content = JSON.parse(await readFile(filePath, 'utf-8'));
-          const dirs = path.dirname(jsonFile).split('/').filter(d => d !== '.');
+          const dirs = path.dirname(jsonFile).split(path.sep).filter(d => d !== '.');
           
           const fileKey = fileName.replace(/-/g, ' ')
             .split(' ')
@@ -371,11 +374,8 @@ async function createMetaFilesForAllFolders() {
           };
         }
 
-        const metaDataPath = path.join(sectionPath, '_meta.json');
-        if (!existsSync(metaDataPath)) {
-          await writeFile(metaDataPath, JSON.stringify(meta, null, 2));
-          console.log(`Created meta file: ${metaDataPath}`);
-        }
+        await writeFile(metaPath, JSON.stringify(meta, null, 2));
+        console.log(`Created/Updated meta file: ${metaPath}`);
       }
     }
   } catch (error) {


### PR DESCRIPTION
# Update Akira Docs Content Structure

- **Purpose:**
 Restructure the content organization and metadata for the Akira Docs platform.
- **Key Changes:**
  - Removed the `en/docs/getting-started` and `en/docs/guides` subdirectories, consolidating content under the top-level `en/docs` directory.
  - Updated the `_meta.json` files to reflect the new content structure, ensuring consistent paths and metadata.
  - Simplified the path structure by removing the language prefix (`/en`) from the article and documentation URLs.
- **Impact:**
 These changes will streamline the content organization, making it easier to navigate and maintain the Akira Docs platform. The simplified URL structure will also improve the user experience.

> ✨ Generated with love by [Kaizen](https://cloudcode.ai) ❤️


<details>
<summary>Original Description</summary>
## 🔍 Description
<!-- What does this PR do? -->

## Type
- [ ] 🐛 Bug Fix
- [ ] ✨ Feature
- [ ] 📚 Documentation
- [ ] 🔧 Other: _____

## Checklist
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Added/updated tests (if needed)
</details>

