### PR TITLE
added option to skip the configuration part

### DIFF
--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-akiradocs",
-  "version": "1.0.47",
+  "version": "1.0.48",
   "description": "Create Akira Docs documentation sites with one command",
   "main": "./dist/index.js",
   "type": "module",

--- a/packages/create-app/src/index.ts
+++ b/packages/create-app/src/index.ts
@@ -173,16 +173,37 @@ async function main() {
 
   cli
     .command('[directory]', 'Create a new Akira Docs site')
-    .action(async (directory: string = '.') => {
+    .option('--yes', 'Skip prompts and use default values')
+    .action(async (directory: string = '.', options: { yes?: boolean }) => {
       try {
-        const editorResponse = await enquirer.prompt<{ includeEditor: boolean }>({
-          type: 'confirm',
-          name: 'includeEditor',
-          message: 'Would you like to include the local editor? (Recommended for development)',
-          initial: true,
-        });
+        let editorResponse;
+        let configAnswers;
 
-        const configAnswers = await promptConfigQuestions();
+        if (options.yes) {
+          // Use default values without prompting
+          editorResponse = { includeEditor: true };
+          configAnswers = {
+            siteTitle: 'My Documentation',
+            siteDescription: 'Documentation powered by Akira Docs',
+            companyName: 'My Company',
+            githubUrl: '',
+            twitterUrl: '',
+            linkedinUrl: '',
+            enableAnalytics: false,
+            googleAnalyticsId: '',
+            enableAutoTranslate: false
+          };
+        } else {
+          // Existing prompt flow
+          editorResponse = await enquirer.prompt<{ includeEditor: boolean }>({
+            type: 'confirm',
+            name: 'includeEditor',
+            message: 'Would you like to include the local editor? (Recommended for development)',
+            initial: true,
+          });
+
+          configAnswers = await promptConfigQuestions();
+        }
 
         const spinner = ora('Creating project...').start();
 


### PR DESCRIPTION
# Update create-akiradocs to Version 1.0.48

- **Purpose:**
 Increment version and enhance CLI functionality for creating Akira Docs sites.
- **Key Changes:**
  - Updated version from 1.0.47 to 1.0.48 in package.json.
  - Added `--yes` option to skip prompts and use default values during site creation.
  - Refactored prompt logic to handle both default values and user inputs.
- **Impact:**
 Improves user experience by allowing faster project setup with predefined configurations.

> ✨ Generated with love by [Kaizen](https://cloudcode.ai) ❤️


<details>
<summary>Original Description</summary>
## 🔍 Description
<!-- What does this PR do? -->

## Type
- [ ] 🐛 Bug Fix
- [ ] ✨ Feature
- [ ] 📚 Documentation
- [ ] 🔧 Other: _____

## Checklist
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Added/updated tests (if needed)
</details>

